### PR TITLE
filter zero value timestamp metrics

### DIFF
--- a/legacy_status_collector.go
+++ b/legacy_status_collector.go
@@ -90,12 +90,14 @@ func (c *LegacyStatusCollector) Collect(ch chan<- prometheus.Metric) error {
 				t1 := timeForCreatedCondition(p)
 				t2 := m.GetCreationTimestamp().Time
 
-				ch <- prometheus.MustNewConstMetric(
-					legacyCreationSecondsCollectorDescription,
-					prometheus.GaugeValue,
-					t1.Sub(t2).Seconds(),
-					m.GetName(),
-				)
+				if !t1.IsZero() && !t2.IsZero() {
+					ch <- prometheus.MustNewConstMetric(
+						legacyCreationSecondsCollectorDescription,
+						prometheus.GaugeValue,
+						t1.Sub(t2).Seconds(),
+						m.GetName(),
+					)
+				}
 			}
 
 			{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6144. There are clusters for which we do not track any proper timestamp. When we find one of older clusters which is zero, we do not emit metrics for it. 