### PR TITLE
Fix k8sclient config, missing logger

### DIFF
--- a/create.go
+++ b/create.go
@@ -244,6 +244,7 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 			}
 
 			clientsConfig := k8sclient.ClientsConfig{
+				Logger:     r.logger,
 				RestConfig: restConfig,
 			}
 			k8sClients, err := k8sclient.NewClients(clientsConfig)


### PR DESCRIPTION
Towards giantswarm/giantswarm#7675

While testing https://github.com/giantswarm/azure-operator/pull/603 uncovered this bug. (see e2e test azure-operator logs
https://6252-99101543-gh.circle-artifacts.com/0/logs/giantswarm-azure-operator-9fd7d67f9-pq5k9-logs.txt )
This PR fixes it.