### PR TITLE
Filtering tenant unavailable error and cancel the resource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -91,11 +91,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e9e6c4c2ae7f624a6eb1b768c582c05f200041de51faf5151b8e074eae917b57"
+  digest = "1:91c99bd60da349380e5912ca7a44de1ad3dc5540b6469685cd88fd6779c7ff2e"
   name = "github.com/giantswarm/errors"
   packages = ["tenant"]
   pruneopts = "NUT"
-  revision = "2640113be13f2eec85fe785ed74418a1a2852e5d"
+  revision = "e5b9af3cd373291dff7fc430e3f76bfd2b06b98b"
 
 [[projects]]
   branch = "master"

--- a/create.go
+++ b/create.go
@@ -244,8 +244,6 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 				r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
 			} else if err != nil {
 				return nil, microerror.Mask(err)
-			} else {
-				r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
 			}
 
 			clientsConfig := k8sclient.ClientsConfig{
@@ -259,6 +257,7 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 
 			k8sClient = k8sClients.K8sClient()
 		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
 
 		o := metav1.ListOptions{}
 		list, err := k8sClient.CoreV1().Nodes().List(o)

--- a/create.go
+++ b/create.go
@@ -52,7 +52,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 
 			patches, err := r.computeCreateEventPatches(ctx, newObj)
-			if err != nil {
+			if tenant.IsAPINotAvailable(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+				return nil
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 
@@ -248,57 +253,48 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 				RestConfig: restConfig,
 			}
 			k8sClients, err := k8sclient.NewClients(clientsConfig)
-			if tenant.IsAPINotAvailable(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
-				return patches, nil
-			} else if err != nil {
+			if err != nil {
 				return nil, microerror.Mask(err)
 			}
 
 			k8sClient = k8sClients.K8sClient()
 		}
 
-		if k8sClient != nil {
-			o := metav1.ListOptions{}
-			list, err := k8sClient.CoreV1().Nodes().List(o)
-			if tenant.IsAPINotAvailable(err) {
-				// fall through
-				r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
-			} else if err != nil {
-				return nil, microerror.Mask(err)
-			} else {
-				var nodes []providerv1alpha1.StatusClusterNode
+		o := metav1.ListOptions{}
+		list, err := k8sClient.CoreV1().Nodes().List(o)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		var nodes []providerv1alpha1.StatusClusterNode
 
-				for _, node := range list.Items {
-					l := node.GetLabels()
-					n := node.GetName()
+		for _, node := range list.Items {
+			l := node.GetLabels()
+			n := node.GetName()
 
-					labelProvider := "giantswarm.io/provider"
-					p, ok := l[labelProvider]
-					if !ok {
-						return nil, microerror.Maskf(missingLabelError, labelProvider)
-					}
-					labelVersion := p + "-operator.giantswarm.io/version"
-					v, ok := l[labelVersion]
-					if !ok {
-						return nil, microerror.Maskf(missingLabelError, labelVersion)
-					}
-
-					nodes = append(nodes, providerv1alpha1.NewStatusClusterNode(n, v, l))
-				}
-
-				nodesDiffer := nodes != nil && !allNodesEqual(clusterStatus.Nodes, nodes)
-
-				if nodesDiffer {
-					patches = append(patches, Patch{
-						Op:    "replace",
-						Path:  "/status/cluster/nodes",
-						Value: nodes,
-					})
-
-					r.logger.LogCtx(ctx, "level", "info", "message", "setting status nodes")
-				}
+			labelProvider := "giantswarm.io/provider"
+			p, ok := l[labelProvider]
+			if !ok {
+				return nil, microerror.Maskf(missingLabelError, labelProvider)
 			}
+			labelVersion := p + "-operator.giantswarm.io/version"
+			v, ok := l[labelVersion]
+			if !ok {
+				return nil, microerror.Maskf(missingLabelError, labelVersion)
+			}
+
+			nodes = append(nodes, providerv1alpha1.NewStatusClusterNode(n, v, l))
+		}
+
+		nodesDiffer := nodes != nil && !allNodesEqual(clusterStatus.Nodes, nodes)
+
+		if nodesDiffer {
+			patches = append(patches, Patch{
+				Op:    "replace",
+				Path:  "/status/cluster/nodes",
+				Value: nodes,
+			})
+
+			r.logger.LogCtx(ctx, "level", "info", "message", "setting status nodes")
 		}
 	}
 

--- a/create.go
+++ b/create.go
@@ -248,7 +248,10 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 				RestConfig: restConfig,
 			}
 			k8sClients, err := k8sclient.NewClients(clientsConfig)
-			if err != nil {
+			if tenant.IsAPINotAvailable(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+				return patches, nil
+			} else if err != nil {
 				return nil, microerror.Mask(err)
 			}
 
@@ -260,6 +263,7 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 			list, err := k8sClient.CoreV1().Nodes().List(o)
 			if tenant.IsAPINotAvailable(err) {
 				// fall through
+				r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
 			} else if err != nil {
 				return nil, microerror.Mask(err)
 			} else {

--- a/vendor/github.com/giantswarm/errors/tenant/error.go
+++ b/vendor/github.com/giantswarm/errors/tenant/error.go
@@ -22,6 +22,9 @@ var (
 		// A regular expression representing timeout errors related to establishing
 		// TCP connections to tenant clusters while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp .* i/o timeout`),
+		// A regular expression representing timeout errors related to awaiting headers
+		// from the tenant API connection.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..* .* \(Client.Timeout exceeded while awaiting headers\)`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),


### PR DESCRIPTION
After having new k8sclient/statusresources around it, kvm-operator having a problem with reconciliation, which keep canceling whole steps from the first `status` resource. 
```
D 12/12 16:30:50 /apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/d60vp nodev26 created Kubernetes client for tenant cluster | kvm-operator/service/controller/v26/resource/node/create.go:43 | event=update | version=177231311
E 12/12 16:30:50 /apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/d60vp failed processing event | operatorkit/controller/controller.go:493 | event=update | version=177231311
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:599:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/basic_resource.go:43:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:64:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:52:
	/go/src/github.com/giantswarm/kvm-operator/service/controller/v26/resource/node/create.go:51:
	/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/k8sclient/clients.go:117:
	Get https://api.d60vp.k8s.geckon.gridscale.kvm.gigantic.io/api?timeout=10s: x509: certificate is valid for ingress.local, not api.d60vp.k8s.geckon.gridscale.kvm.gigantic.io
```

This is due to we are creating k8sclient using dynamic REST mapper. We should cancel the resource gracefully in this case. 