### PR TITLE
Replace /status init with /status/cluster init

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -3,6 +3,7 @@ package statusresource
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"time"
 
@@ -141,11 +142,11 @@ func ensureDefaultPatches(clusterStatus providerv1alpha1.StatusCluster, patches 
 	nodesEmpty := clusterStatus.Nodes == nil
 	versionsEmpty := clusterStatus.Versions == nil
 
-	if conditionsEmpty && nodesEmpty && versionsEmpty {
+	if reflect.DeepEqual(clusterStatus, providerv1alpha1.StatusCluster{}) {
 		patches = append(patches, Patch{
 			Op:    "add",
-			Path:  "/status",
-			Value: Status{},
+			Path:  "/status/cluster",
+			Value: providerv1alpha1.StatusCluster{},
 		})
 	}
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#7675

While testing https://github.com/giantswarm/aws-operator/pull/2090 aws-operator legacy branch e2e tests started failing, different network would be assigned multiple times even after tenant cluster is already up causing CF stack updates to fail since various AWS resources once created in one network cannot be reassigned to a different one. After analysis it turned out statusresource reconciliation was clearing `/status`, resetting initial network allocation stored under `/status/cluster/network`.

This PR replaces `/status` initialization with `/status/cluster` initialization, and only under condition that ClusterStatus of underlying resource is empty struct.