### PR TITLE
Skip nodes if unable to get TC certs/client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip iteration of nodes when tenant cluster certificates / client is not
+  available. This prevents error in the beginning of cluster creation.
 
 
 ## [0.3.0] 2020-04-20

--- a/create.go
+++ b/create.go
@@ -242,6 +242,7 @@ func (r *Resource) computeCreateEventPatches(ctx context.Context, obj interface{
 			if tenantcluster.IsTimeout(err) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
 				r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+				return patches, nil
 			} else if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/resource.go
+++ b/resource.go
@@ -3,6 +3,7 @@ package statusresource
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"time"
@@ -129,6 +130,7 @@ func (r *Resource) applyPatches(ctx context.Context, accessor metav1.Object, pat
 	} else if errors.IsResourceExpired(err) {
 		return microerror.Mask(err)
 	} else if err != nil {
+		r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("unknown error: %#v", err), "stack", microerror.JSON(err))
 		return microerror.Mask(err)
 	}
 


### PR DESCRIPTION
When creating cluster it's normal to not get certs / client for TC in the
beginning. Skip iteration of nodes (that don't exist yet) and return prepared
patches.

## Checklist

- [x] Update changelog in CHANGELOG.md.
